### PR TITLE
Use git from wandisco repositories on centos 7

### DIFF
--- a/files/enable-sclo-git25.sh
+++ b/files/enable-sclo-git25.sh
@@ -1,1 +1,0 @@
-source scl_source enable sclo-git25

--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -1,24 +1,30 @@
 ---
-- name: Install sclo-git25
+- name: Remove sclo-git25 packages
   yum:
     name:
+      - sclo-git25-git
       - sclo-git25
+    state: absent
+    use_backend: yum
+  become: true
+
+- name: Remove sclo-git25 envvars for all users
+  file:
+    dest: /etc/profile.d/enable-sclo-git25.sh
+    state: absent
+    mode: u=rwx,g=rx,o=rx
+  become: true
+
+- name: Add wandisco git repository package
+  yum:
+    name: http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-2.noarch.rpm
     state: present
     use_backend: yum
   become: true
 
-- name: Enable sclo-git25 globally for all users
-  # See https://developers.redhat.com/blog/2014/03/19/permanently-enable-a-software-collection/
-  copy:
-    src: enable-sclo-git25.sh
-    dest: /etc/profile.d/enable-sclo-git25.sh
-    mode: u=rwx,g=rx,o=rx
-  become: true
-
-- name: Install git
+- name: Add wandisco git package
   yum:
-    name:
-      - sclo-git25-git
+    name: git>=2.20
     state: present
     use_backend: yum
   become: true

--- a/tasks/CentOS.yml
+++ b/tasks/CentOS.yml
@@ -10,9 +10,14 @@
 
 - name: Remove sclo-git25 envvars for all users
   file:
-    dest: /etc/profile.d/enable-sclo-git25.sh
+    path: /etc/profile.d/enable-sclo-git25.sh
     state: absent
-    mode: u=rwx,g=rx,o=rx
+  become: true
+
+- name: Remove sclo-git25 configuration
+  file:
+    path: /opt/rh/sclo-git25/root/etc/gitconfig
+    state: absent
   become: true
 
 - name: Add wandisco git repository package
@@ -32,6 +37,6 @@
 - name: Add global gitconfig configuration
   template:
     src: "global-gitconfig.j2"
-    dest: "/opt/rh/sclo-git25/root/etc/gitconfig"
+    dest: "/etc/gitconfig"
     mode: 0644
   become: true


### PR DESCRIPTION
The version provided by this repository fixes an issue reported by teamcity (it will no longer support the older version provided on centos 7 in the future) and visual studio code